### PR TITLE
Tests: Add software tests and CI/GHA configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "pip" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,70 @@
+name: "Tests"
+
+on:
+  push:
+    branches: [ main ]
+  pull_request: ~
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  test-cpython:
+    name: "
+    CPython ${{ matrix.python-version }}
+    "
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: ['ubuntu-latest']
+        python-version: ['3.13']
+
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+
+    services:
+      cratedb:
+        image: crate/crate:nightly
+        ports:
+          - 4200:4200
+
+    steps:
+
+      - name: Acquire sources
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: x64
+          cache: 'pip'
+          cache-dependency-path: |
+            pyproject.toml
+            requirements*.txt
+
+      - name: Set up project tools
+        run: uv pip install --system --requirement=requirements.txt --requirement=requirements-dev.txt
+
+      - name: Run linters and software tests
+        run: poe test
+
+      # https://github.com/codecov/codecov-action
+      - name: Upload coverage results to Codecov
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        with:
+          files: ./coverage.xml
+          flags: main
+          env_vars: OS,PYTHON
+          name: codecov-umbrella
+          fail_ci_if_error: false

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .env
 .idea
 __pycache__
+.coverage*
+coverage.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # micropython-cratedb - A CrateDB Driver for MicroPython
 
+[![Tests](https://github.com/crate/micropython-cratedb/actions/workflows/tests.yml/badge.svg)](https://github.com/crate/micropython-cratedb/actions/workflows/tests.yml)
+
 ## Introduction
 
 micropython-cratedb is a [CrateDB](https://cratedb.com) driver for the [MicroPython](https://micropython.org) language.  It connects to CrateDB using the [HTTP Endpoint](https://cratedb.com/docs/crate/reference/en/latest/interfaces/http.html).

--- a/examples/picow_demo.py
+++ b/examples/picow_demo.py
@@ -88,7 +88,7 @@ while True:
         )
 
         if response["rowcount"] == 1:
-            print(f"Average temperature over last 24hrs: {response["rows"][0][0]}")
+            print(f"Average temperature over last 24hrs: {response['rows'][0][0]}")
             num_iterations = 0
 
     time.sleep(10)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,122 @@
+[tool.ruff]
+line-length = 100
+
+extend-exclude = [
+]
+
+lint.select = [
+  # Builtins
+  "A",
+  # Bugbear
+  "B",
+  # comprehensions
+  "C4",
+  # Pycodestyle
+  "E",
+  # eradicate
+  "ERA",
+  # Pyflakes
+  "F",
+  # isort
+  "I",
+  # return
+  "RET",
+  # Bandit
+  "S",
+  # print
+  "T20",
+  "W",
+  # flake8-2020
+  "YTT",
+]
+
+lint.extend-ignore = [
+  # Unnecessary `elif` after `return` statement
+  "RET505",
+  # Probable insecure usage of temporary file or directory
+  "S108",
+  # Possible SQL injection vector through string-based query construction
+  "S608",
+]
+
+lint.per-file-ignores."examples/*" = [
+  "ERA001", # Found commented-out code
+  "T201",   # Allow `print`
+]
+
+lint.per-file-ignores."tests/*" = [
+  "S101",   # Allow use of `assert`
+]
+
+[tool.pytest.ini_options]
+addopts = """
+  -rfEXs -p pytester --strict-markers --verbosity=3
+  --cov --cov-report=term-missing --cov-report=xml
+  """
+minversion = "2.0"
+log_level = "DEBUG"
+log_cli_level = "DEBUG"
+log_format = "%(asctime)-15s [%(name)-36s] %(levelname)-8s: %(message)s"
+xfail_strict = true
+
+
+[tool.coverage.paths2]
+source = [
+  ".",
+  "examples",
+]
+
+[tool.coverage.run]
+branch = false
+source = [
+  ".",
+  "examples",
+]
+omit = [
+  "tests/*",
+]
+
+[tool.coverage.report]
+fail_under = 0
+show_missing = true
+exclude_lines = [
+  "# pragma: no cover",
+  "raise NotImplemented",
+]
+
+
+# ===================
+# Tasks configuration
+# ===================
+
+[tool.poe.tasks]
+
+check = [
+  "lint",
+  "test",
+]
+
+format = [
+  { cmd = "ruff format ." },
+  # Configure Ruff not to auto-fix (remove!):
+  # unused imports (F401), unused variables (F841), `print` statements (T201), and commented-out code (ERA001).
+  { cmd = "ruff check --fix --ignore=ERA --ignore=F401 --ignore=F841 --ignore=T20 --ignore=ERA001 ." },
+  { cmd = "pyproject-fmt --keep-full-version pyproject.toml" },
+]
+
+lint = [
+  { cmd = "ruff format --check ." },
+  { cmd = "ruff check ." },
+  { cmd = "validate-pyproject pyproject.toml" },
+]
+
+
+[tool.poe.tasks.test]
+cmd = "pytest"
+help = "Invoke software tests"
+
+[tool.poe.tasks.test.args.expression]
+options = [ "-k" ]
+
+[tool.poe.tasks.test.args.marker]
+options = [ "-m" ]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+poethepoet
+pyproject-fmt<3
+pytest<9
+pytest-cov<7
+ruff<0.8
+validate-pyproject<0.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,46 @@
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def boot():
+    """
+    Add current working dir to Python module search path.
+
+    This is needed to make the interpreter pick up `cratedb.py`
+    in the top-level directory.
+    """
+    os.environ["PYTHONPATH"] = str(Path.cwd())
+
+
+def test_example_usage(capfd):
+    """
+    Validate `examples/example_usage.py` runs to completion.
+    """
+    subprocess.check_call(["python", "examples/example_usage.py"])
+    out, err = capfd.readouterr()
+    assert "Create table" in out
+    assert "Drop table" in out
+
+
+def test_object_examples(capfd):
+    """
+    Validate `examples/object_examples.py` runs to completion.
+    """
+    subprocess.check_call(["python", "examples/object_examples.py"])
+    out, err = capfd.readouterr()
+    assert "Create table" in out
+    assert "Drop table" in out
+
+
+def test_picow_demo(capfd):
+    """
+    Validate `examples/picow_demo.py` fails, because it needs real hardware.
+    """
+    returncode = subprocess.call(["python", "examples/picow_demo.py"])
+    assert returncode == 1
+    out, err = capfd.readouterr()
+    assert "ModuleNotFoundError: No module named 'machine'" in err


### PR DESCRIPTION
## About
Based on GH-23, this adds a a few bits of configuration to use the files in the "examples" folder as test cases. On top, a CI configuration using GHA will automate things well.

## Status
Currently, it is still about CPython only. Enabling a MicroPython test matrix slot would still be up for another iteration.

## Remarks
Please integrate the other patch first, because this one is stacked upon it.
