### PR TITLE
Chore: Format code using Ruff. Satisfy and enable linter on CI.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
         run: uv pip install --system --requirement=requirements.txt --requirement=requirements-dev.txt
 
       - name: Run linters and software tests
-        run: poe test
+        run: poe check
 
       # https://github.com/codecov/codecov-action
       - name: Upload coverage results to Codecov

--- a/examples/example_usage.py
+++ b/examples/example_usage.py
@@ -1,5 +1,7 @@
+# ruff: noqa: W291 Trailing whitespace
+
 # Example script showing different types of interactions with
-# CrateDB. This has no hardware dependencies so should run 
+# CrateDB. This has no hardware dependencies so should run
 # in any MicroPython environment. You will need to edit the
 # code below to use your CrateDB credentials.
 
@@ -20,7 +22,9 @@ crate = cratedb.CrateDB(
 try:
     # Create a table.
     print("Create table.")
-    response = crate.execute("create table driver_test(id TEXT, val1 bigint, val2 bigint, val3 boolean)")
+    response = crate.execute(
+        "create table driver_test(id TEXT, val1 bigint, val2 bigint, val3 boolean)"
+    )
     # response:
     # {'rows': [[]], 'rowcount': 1, 'cols': [], 'duration': 119.652275}
     print(response)
@@ -29,10 +33,7 @@ try:
     print("Bulk insert.")
     response = crate.execute(
         "insert into driver_test (id, val1, val2, val3) values (?, ?, ?, ?)",
-        [
-            [ "a", 2, 3, True ],
-            [ "b", 3, 4, False ]
-        ]
+        [["a", 2, 3, True], ["b", 3, 4, False]],
     )
     # response:
     # {'results': [{'rowcount': 1}, {'rowcount': 1}], 'cols': [], 'duration': 6.265751}
@@ -42,14 +43,14 @@ try:
     print("Select with column data types.")
     response = crate.execute("select * from driver_test", with_types=True)
     # response:
-    # {'col_types': [4, 10, 10, 3], 'cols': ['id', 'val1', 'val2', 'val3'], 'rowcount': 2, 'rows': [['b', 3, 4, False], ['a', 2, 3, True]], 'duration': 4.378391}
+    # {'col_types': [4, 10, 10, 3], 'cols': ['id', 'val1', 'val2', 'val3'], 'rowcount': 2,
+    #  'rows': [['b', 3, 4, False], ['a', 2, 3, True]], 'duration': 4.378391}
     print(response)
 
     # SELECT with parameter substitution.
     print("Select with parameter substitution.")
     response = crate.execute(
-        "select val1, val2 from driver_test where val1 > ? and val2 < ?",
-        [ 1, 4 ]
+        "select val1, val2 from driver_test where val1 > ? and val2 < ?", [1, 4]
     )
     # response:
     # {'rows': [[2, 3]], 'rowcount': 1, 'cols': ['val1', 'val2'], 'duration': 3.266117}
@@ -59,7 +60,7 @@ try:
     print("Insert with parameter substitution.")
     response = crate.execute(
         "insert into driver_test (id, val1, val2, val3) values (?, ?, ?, ?)",
-        [ "d", 1, 9, False ]
+        ["d", 1, 9, False],
     )
     # response:
     # {'rows': [[]], 'rowcount': 1, 'cols': [], 'duration': 5.195949}
@@ -69,8 +70,8 @@ try:
     print("Insert with parameter substitution and no response processing.")
     response = crate.execute(
         "insert into driver_test (id, val1, val2, val3) values (?, ?, ?, ?)",
-        [ "e", 4, 12, True ],
-        return_response=False
+        ["e", 4, 12, True],
+        return_response=False,
     )
     # response:
     # None

--- a/examples/object_examples.py
+++ b/examples/object_examples.py
@@ -1,5 +1,7 @@
+# ruff: noqa: W291 Trailing whitespace
+
 # Example script showing different types of interactions with
-# objects in CrateDB. This has no hardware dependencies so should 
+# objects in CrateDB. This has no hardware dependencies so should
 # run in any MicroPython environment. You will need to edit the
 # code below to use your CrateDB credentials.
 
@@ -23,7 +25,9 @@ try:
 
     # Create a table, using a dynamic object column.
     print("Create table.")
-    response = crate.execute("CREATE TABLE driver_object_test (id TEXT PRIMARY KEY, data OBJECT(DYNAMIC))")
+    response = crate.execute(
+        "CREATE TABLE driver_object_test (id TEXT PRIMARY KEY, data OBJECT(DYNAMIC))"
+    )
 
     # response:
     # {'rows': [[]], 'rowcount': 1, 'cols': [], 'duration': 270.4579}
@@ -32,45 +36,36 @@ try:
     # Insert an object with arbitrary complexity.
     print("INSERT a row containing an object.")
     example_obj = {
-        "sensor_readings": {
-            "temp": 23.3,
-            "humidity": 61.2
-        },
+        "sensor_readings": {"temp": 23.3, "humidity": 61.2},
         "metadata": {
             "software_version": "1.19",
             "battery_percentage": 57,
-            "uptime": 2851200
-        }
+            "uptime": 2851200,
+        },
     }
 
     response = crate.execute(
-        "INSERT INTO driver_object_test (id, data) VALUES (?, ?)",
-        [
-            "2cae54",
-            example_obj
-        ]
+        "INSERT INTO driver_object_test (id, data) VALUES (?, ?)", ["2cae54", example_obj]
     )
 
-    # response: 
+    # response:
     # {'rows': [[]], 'rowcount': 1, 'cols': [], 'duration': 334.37607}
     print(response)
 
     # Select query returning the entire object.
     print("SELECT the whole object.")
     response = crate.execute(
-        "SELECT data FROM driver_object_test WHERE id = ?",
-        [
-            "2cae54"
-        ]
+        "SELECT data FROM driver_object_test WHERE id = ?", ["2cae54"]
     )
 
     # response:
     # {'rows': [
-    #     [{
-    #         'metadata': {'software_version': '1.19', 'uptime': 2851200, 'battery_percentage': 57}, 
-    #         'sensor_readings': {'humidity': 61.2, 'temp': 23.3}}
-    #     ]
-    #  ], 'rowcount': 1, 'cols': ['data'], 'duration': 21.946375
+    #   [{
+    #     'metadata': {'software_version': '1.19', 'uptime': 2851200,
+    #                  'battery_percentage': 57},
+    #     'sensor_readings': {'humidity': 61.2, 'temp': 23.3}}
+    #   ]
+    # ], 'rowcount': 1, 'cols': ['data'], 'duration': 21.946375
     # }
     print(response)
 
@@ -83,15 +78,13 @@ try:
                 data['sensor_readings'] AS sensor_readings 
            FROM driver_object_test 
            WHERE id = ?""",
-        [
-            "2cae54"
-        ]
+        ["2cae54"],
     )
 
     # response:
     # {'rows': [
     #     [2851200, {'humidity': 61.2, 'temp': 23.3}]
-    #  ], 
+    #  ],
     #  'rowcount': 1, 'cols': ['uptime', 'sensor_readings'], 'duration': 4.047666
     # }
     print(response)
@@ -100,55 +93,46 @@ try:
     response = crate.execute(
         "INSERT INTO driver_object_test (id, data) VALUES (?, ?)",
         [
-            [ 
-                "2cae56", 
+            [
+                "2cae56",
                 {
-                    "sensor_readings": {
-                    "temp": 21.8,
-                    "humidity": 57.9
-                    },
+                    "sensor_readings": {"temp": 21.8, "humidity": 57.9},
                     "metadata": {
                         "software_version": "1.19",
                         "battery_percentage": 43,
-                        "uptime": 2851643
-                    }
-                } 
+                        "uptime": 2851643,
+                    },
+                },
             ],
             [
-                "1d452b", 
+                "1d452b",
                 {
-                    "sensor_readings": {
-                        "temp": 11.4,
-                        "humidity": 43.9
-                    },
+                    "sensor_readings": {"temp": 11.4, "humidity": 43.9},
                     "metadata": {
                         "software_version": "1.20",
                         "battery_percentage": 17,
-                        "uptime": 853436
-                    }
-                } 
-            ],
-            [ 
-                "4e000f", 
-                {
-                    "sensor_readings": {
-                        "temp": 26.8,
-                        "humidity": 78.9
+                        "uptime": 853436,
                     },
+                },
+            ],
+            [
+                "4e000f",
+                {
+                    "sensor_readings": {"temp": 26.8, "humidity": 78.9},
                     "metadata": {
                         "software_version": "1.19",
                         "battery_percentage": 84,
-                        "uptime": 1468356
+                        "uptime": 1468356,
                     },
-                } 
-            ]
-        ]
+                },
+            ],
+        ],
     )
 
     # response:
     # {'results': [
-    #     {'rowcount': 1}, 
-    #     {'rowcount': 1}, 
+    #     {'rowcount': 1},
+    #     {'rowcount': 1},
     #     {'rowcount': 1}
     #  ], 'cols': [], 'duration': 4.426417
     # }
@@ -156,11 +140,10 @@ try:
 
     # Tells the database to refresh the table.  This is here to make sure that the
     # subsequent SELECT has the data from the INSERT above.  This is not needed in
-    # real application code.  
+    # real application code.
     # See https://cratedb.com/docs/crate/reference/en/latest/sql/statements/refresh.html
     # for details.
     crate.execute("REFRESH TABLE driver_object_test", return_response=False)
-
 
     # SELECT example that filters by an object property in the WHERE clause.
     print("SELECT and filter by an object property in the WHERE clause.")
@@ -173,8 +156,8 @@ try:
 
     # response:
     # { 'rows': [
-    #     ['4e000f', {'humidity': 78.90000000000001, 'temp': 26.8}], 
-    #     ['2cae54', {'humidity': 61.2, 'temp': 23.3}], 
+    #     ['4e000f', {'humidity': 78.90000000000001, 'temp': 26.8}],
+    #     ['2cae54', {'humidity': 61.2, 'temp': 23.3}],
     #     ['2cae56', {'humidity': 57.9, 'temp': 21.8}]
     #   ], 'rowcount': 3, 'cols': ['id', 'sensor_readings'], 'duration': 13.790875}
     print(response)
@@ -191,58 +174,39 @@ try:
                 "co",
                 {
                     "name": "Colombia",
-                    "borders": [
-                        "Brazil", "Peru", "Panama", "Ecuador", "Venezuela"
-                    ],
-                    "currency": {
-                        "code": "COP",
-                        "name": "Colobian Peso"
-                    },
+                    "borders": ["Brazil", "Peru", "Panama", "Ecuador", "Venezuela"],
+                    "currency": {"code": "COP", "name": "Colobian Peso"},
                     "rates": [
-                        {
-                            "code": "USD",
-                            "rate": "0.000235"
-                        },
-                        {
-                            "code": "EUR",
-                            "rate": "0.000216"
-                        },
-                        {
-                            "code": "JPY",
-                            "rate": "0.035154"
-                        }
-                    ]
-                }
+                        {"code": "USD", "rate": "0.000235"},
+                        {"code": "EUR", "rate": "0.000216"},
+                        {"code": "JPY", "rate": "0.035154"},
+                    ],
+                },
             ],
             [
                 "br",
                 {
                     "name": "Brazil",
                     "borders": [
-                        "Argentina", "Bolivia", "Colombia", "French Guiana",
-                        "Guyana", "Paraguay", "Suriname", "Uruguay", "Venezuela"
+                        "Argentina",
+                        "Bolivia",
+                        "Colombia",
+                        "French Guiana",
+                        "Guyana",
+                        "Paraguay",
+                        "Suriname",
+                        "Uruguay",
+                        "Venezuela",
                     ],
-                    "currency": {
-                        "code": "BRL",
-                        "name": "Brazilian Real"
-                    },
+                    "currency": {"code": "BRL", "name": "Brazilian Real"},
                     "rates": [
-                        {
-                            "code": "USD",
-                            "rate": "0.176620"
-                        },
-                        {
-                            "code": "EUR",
-                            "rate": "0.162409"
-                        },
-                        {
-                            "code": "JPY",
-                            "rate": "26.432108"
-                        }
-                    ]
-                }
-            ]
-        ]
+                        {"code": "USD", "rate": "0.176620"},
+                        {"code": "EUR", "rate": "0.162409"},
+                        {"code": "JPY", "rate": "26.432108"},
+                    ],
+                },
+            ],
+        ],
     )
 
     # response:
@@ -251,17 +215,19 @@ try:
 
     # Some examples showing how to access data inside arrays.
     # See also https://cratedb.com/docs/crate/reference/en/latest/general/builtins/scalar-functions.html#array-functions
-    
+
     # Simple array... which countries does Colombia share a border with?
     print("Arrays... countries sharing a border with Colombia.")
     response = crate.execute(
         """
-            SELECT data['borders'] as shares_border_with FROM driver_object_test WHERE id = 'co'
+            SELECT data['borders'] as shares_border_with 
+            FROM driver_object_test WHERE id = 'co'
         """
     )
 
     # response:
-    # {'rows': [[['Brazil', 'Peru', 'Panama', 'Ecuador', 'Venezuela']]], 'rowcount': 1, 'cols': ['shares_border_with'], 'duration': 50.105873}
+    # {'rows': [[['Brazil', 'Peru', 'Panama', 'Ecuador', 'Venezuela']]],
+    #  'rowcount': 1, 'cols': ['shares_border_with'], 'duration': 50.105873}
     print(response)
 
     # How many countries does Brazil share a border with?
@@ -269,7 +235,8 @@ try:
     response = crate.execute(
         # 1 here is the array dimension to get the length of, as arrays can be nested.
         """
-            SELECT array_length(data['borders'], 1) as how_many FROM driver_object_test WHERE id = 'br'
+        SELECT array_length(data['borders'], 1) AS how_many 
+        FROM driver_object_test WHERE id = 'br'
         """
     )
 
@@ -277,16 +244,19 @@ try:
     # {'rows': [[9]], 'rowcount': 1, 'cols': ['how_many'], 'duration': 1.397291}
     print(response)
 
-    # What are the 2nd, 3rd and 4th countries in Brazil's borders array? (Arrays are 1 indexed).
+    # What are the 2nd, 3rd and 4th countries in Brazil's borders array?
+    # Arrays are 1-indexed.
     print("Array slicing.")
     response = crate.execute(
         """
-            SELECT array_slice(data['borders'], 2, 4) AS slice FROM driver_object_test WHERE id = 'br'
+        SELECT array_slice(data['borders'], 2, 4) AS slice 
+        FROM driver_object_test WHERE id = 'br'
         """
     )
 
     # response:
-    # {'rows': [[['Bolivia', 'Colombia', 'French Guiana']]], 'rowcount': 1, 'cols': ['slice'], 'duration': 1.517417}
+    # {'rows': [[['Bolivia', 'Colombia', 'French Guiana']]], 'rowcount': 1,
+    #  'cols': ['slice'], 'duration': 1.517417}
     print(response)
 
     # Example queries for arrays containing objects.
@@ -296,28 +266,31 @@ try:
     print("Mixing objects and arrays...")
     response = crate.execute(
         """
-            SELECT data['rates'][2]['code'] FROM driver_object_test WHERE id='co'
+            SELECT data['rates'][2]['code'] 
+            FROM driver_object_test WHERE id='co'
         """
     )
 
     # response:
-    # {'rows': [['EUR']], 'rowcount': 1, 'cols': ["data[2]['rates']['code']"], 'duration': 0.553541}
+    # {'rows': [['EUR']], 'rowcount': 1,
+    #  'cols': ["data[2]['rates']['code']"], 'duration': 0.553541}
     print(response)
 
-    # Array comparisons. 
+    # Array comparisons.
     # https://cratedb.com/docs/crate/reference/en/latest/general/builtins/array-comparisons.html#sql-array-comparisons
     # Which countries share a border with Paraguay?
     print("Element in array: Who shares a border with Paraguay?")
 
     response = crate.execute(
         """
-            SELECT data['name'] AS name, 'Paraguay' IN (data['borders']) AS borders_paraguay 
-            FROM driver_object_test WHERE id IN ('br', 'co')
+        SELECT data['name'] AS name, 'Paraguay' IN (data['borders']) AS borders_paraguay 
+        FROM driver_object_test WHERE id IN ('br', 'co')
         """
     )
 
     # response:
-    # {'rows': [['Colombia', False], ['Brazil', True]], 'rowcount': 2, 'cols': ['name', 'borders_paraguay'], 'duration': 0.574833}
+    # {'rows': [['Colombia', False], ['Brazil', True]], 'rowcount': 2,
+    #  'cols': ['name', 'borders_paraguay'], 'duration': 0.574833}
     print(response)
 
     # Drop the table.

--- a/examples/picow_demo.py
+++ b/examples/picow_demo.py
@@ -1,11 +1,14 @@
+# ruff: noqa: W291 Trailing whitespace
+
 # micropython-cratedb Example for the Raspberry Pi Pico W.
 # Configure your CrateDB credentials and WiFi SSID
 # and password below before running this.
 
-import machine
-import network
 import sys
 import time
+
+import machine
+import network
 
 import cratedb
 
@@ -42,8 +45,8 @@ try:
             ts TIMESTAMP WITH TIME ZONE GENERATED ALWAYS AS current_timestamp, 
             temp DOUBLE PRECISION
             )
-        """, 
-        return_response = False
+        """,
+        return_response=False,
     )
 
 except Exception as e:
@@ -63,15 +66,11 @@ while True:
     # https://www.coderdojotc.org/micropython/advanced-labs/03-internal-temperature/
     sensor_temp = machine.ADC(4)
     reading = sensor_temp.read_u16() * (3.3 / (65535))
-    temperature = 27 - (reading - 0.706)/0.001721
+    temperature = 27 - (reading - 0.706) / 0.001721
     temperature = round(temperature, 1)
 
     response = crate.execute(
-        "INSERT INTO picow_test (id, temp) VALUES (?, ?)",
-        [
-            ip_addr,
-            temperature
-        ]
+        "INSERT INTO picow_test (id, temp) VALUES (?, ?)", [ip_addr, temperature]
     )
 
     if response["rowcount"] == 1:
@@ -81,10 +80,9 @@ while True:
     # Every 10th iteration let's read back an average value for the last 24hrs.
     if num_iterations == 10:
         response = crate.execute(
-            "SELECT trunc(avg(temp), 1) AS avg_temp FROM picow_test WHERE id=? AND ts >= (CURRENT_TIMESTAMP - INTERVAL '1' DAY)",
-            [
-                ip_addr
-            ]
+            "SELECT trunc(avg(temp), 1) AS avg_temp "
+            "FROM picow_test WHERE id=? AND ts >= (CURRENT_TIMESTAMP - INTERVAL '1' DAY)",
+            [ip_addr],
         )
 
         if response["rowcount"] == 1:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.ruff]
-line-length = 100
+line-length = 90
 
 extend-exclude = [
 ]
@@ -45,7 +45,7 @@ lint.per-file-ignores."examples/*" = [
 ]
 
 lint.per-file-ignores."tests/*" = [
-  "S101",   # Allow use of `assert`
+  "S101", # Allow use of `assert`
 ]
 
 [tool.pytest.ini_options]
@@ -58,7 +58,6 @@ log_level = "DEBUG"
 log_cli_level = "DEBUG"
 log_format = "%(asctime)-15s [%(name)-36s] %(levelname)-8s: %(message)s"
 xfail_strict = true
-
 
 [tool.coverage.paths2]
 source = [
@@ -84,7 +83,6 @@ exclude_lines = [
   "raise NotImplemented",
 ]
 
-
 # ===================
 # Tasks configuration
 # ===================
@@ -109,7 +107,6 @@ lint = [
   { cmd = "ruff check ." },
   { cmd = "validate-pyproject pyproject.toml" },
 ]
-
 
 [tool.poe.tasks.test]
 cmd = "pytest"

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,3 +1,5 @@
+# ruff: noqa: S603, S607
+
 import os
 import subprocess
 from pathlib import Path


### PR DESCRIPTION
## About
A little followup to GH-25, effectively activating the Ruff linter on CI, after formatting the code using `poe format`, and applying a few manual adjustments.
