### PR TITLE
CI: Update configuration for code coverage uploading to Codecov.io

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -70,10 +70,10 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           files: ./coverage.xml
-          flags: main
+          flags: cpython
           env_vars: OS,PYTHON
           name: codecov-umbrella
-          fail_ci_if_error: false
+          fail_ci_if_error: true
 
 
   test-micropython:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # micropython-cratedb - A CrateDB Driver for MicroPython
 
 [![Tests](https://github.com/crate/micropython-cratedb/actions/workflows/tests.yml/badge.svg)](https://github.com/crate/micropython-cratedb/actions/workflows/tests.yml)
+[![Test coverage](https://img.shields.io/codecov/c/gh/crate/micropython-cratedb.svg?style=flat-square)](https://codecov.io/gh/crate/micropython-cratedb/)
 
 ## Introduction
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,9 @@ xfail_strict = true
 branch = false
 source = [
   ".",
-  "examples",
 ]
 omit = [
+  "examples/*",
   "tests/*",
 ]
 


### PR DESCRIPTION
## About

GHA checks on Dependabot update GH-34 succeeded, while [uploading to Codecov.io actually failed](https://github.com/crate/micropython-cratedb/actions/runs/12109266430/job/33758188184?pr=34#step:8:267).

> `Upload failed: {"message":"Token required because branch is protected"}.`
