### PR TITLE
CI: Fix and improve pip/uv installation

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,6 +32,7 @@ jobs:
     env:
       OS: ${{ matrix.os }}
       PYTHON: ${{ matrix.python-version }}
+      UV_SYSTEM_PYTHON: true
 
     services:
       cratedb:
@@ -44,21 +45,23 @@ jobs:
       - name: Acquire sources
         uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          architecture: x64
-          cache: 'pip'
-          cache-dependency-path: |
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          cache-dependency-glob: |
             pyproject.toml
             requirements*.txt
+          cache-suffix: ${{ matrix.python-version }}
+          enable-cache: true
+          version: "latest"
 
       - name: Set up project requirements and tools
-        run: uv pip install --system --requirement=requirements.txt --requirement=requirements-dev.txt
+        run: uv pip install --requirement=requirements.txt --requirement=requirements-dev.txt
 
       - name: Run linters and software tests
         run: poe check-cpython
@@ -94,6 +97,7 @@ jobs:
     env:
       OS: ${{ matrix.os }}
       MICROPYTHON: ${{ matrix.micropython-version }}
+      UV_SYSTEM_PYTHON: true
 
     services:
       cratedb:
@@ -113,7 +117,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v5
       - name: Set up project tools
-        run: uv pip install --system poethepoet
+        run: uv pip install poethepoet
 
       # https://github.com/marketplace/actions/install-micropython
       - name: Set up MicroPython ${{ matrix.micropython-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -89,8 +89,8 @@ jobs:
       matrix:
         os: ['ubuntu-latest']
         micropython-version: [
-          'v1.20.0',
-          'v1.24.0',
+          'v1.22.2',
+          'v1.24.1',
           'v1.25.0-preview',
         ]
 


### PR DESCRIPTION
## About
What the title says. Updating to a newer MicroPython was needed because CI/GHA started failing on MicroPython v1.20.0.

## Reason

> Error: Cache folder path is retrieved for pip but doesn't exist on disk: /home/runner/.cache/pip. This likely indicates that there are no dependencies to cache. Consider removing the cache step if it is not needed.

-- https://github.com/crate/micropython-cratedb/actions/runs/13300222357/job/37196358940#step:13:2